### PR TITLE
fix: add babel plugin to fix ts decorators in sb

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -7,4 +7,16 @@ module.exports = {
     '@storybook/addon-a11y',
   ],
   framework: '@storybook/web-components',
+  babel: async (options) => {
+    Object.assign(
+      options.plugins.find((plugin) =>
+        plugin[0].includes('plugin-proposal-decorators')
+      )[1],
+      {
+        decoratorsBeforeExport: true,
+        legacy: false,
+      }
+    );
+    return options;
+  },
 };

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -7,6 +7,8 @@ module.exports = {
     '@storybook/addon-a11y',
   ],
   framework: '@storybook/web-components',
+  // Babel plugin required to avoid decorator conflicts between Storybook and Lit
+  // More info: https://github.com/storybookjs/storybook/issues/12369#issuecomment-698221904
   babel: async (options) => {
     Object.assign(
       options.plugins.find((plugin) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@babel/plugin-proposal-decorators": "^7.19.1",
         "@open-wc/testing": "^3.1.6",
         "@storybook/addon-a11y": "^6.5.12",
         "@storybook/addon-actions": "^6.5.12",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@babel/plugin-proposal-decorators": "^7.19.1",
     "@open-wc/testing": "^3.1.6",
     "@storybook/addon-a11y": "^6.5.12",
     "@storybook/addon-actions": "^6.5.12",


### PR DESCRIPTION
Decorators were not working properly due to a conflict between the storybook/web-component decorator config and the Lit/Typescript decorator config.

Adding the Babel plugin `plugin-proposal-decorators` with the `legacy` flag set to false enforces storybook to use the more modern Lit/TS config. 

[More info](https://github.com/storybookjs/storybook/issues/12369#issuecomment-698221904)